### PR TITLE
NLP-18-separate-steps

### DIFF
--- a/preprocess/incident_types/column_merge.py
+++ b/preprocess/incident_types/column_merge.py
@@ -1,30 +1,34 @@
 import pandas as pd
 
+from preprocessor import Preprocessor
 from report_data_d import ColName
 
 
-def merge_columns(report_data: pd.DataFrame) -> pd.DataFrame:
-    """Merges the old incident type columns into the new, removes the old.
+class ColumnMerger(Preprocessor):
+    def process(self, report_data: pd.DataFrame) -> pd.DataFrame:
+        """Merges the old incident type columns into the new, removes the old.
 
-    :param report_data:
-    :return: The updated data.
-    """
-    pd.set_option('display.max_columns', None)
-    # create new column and add to end of DataFrame
-    report_data[ColName.INC_T1] = report_data[ColName.INC_T1_OLD].fillna(
-        '') + report_data[ColName.INC_T1].fillna('')
-    # preprocess, replace nan with empty string
-    report_data[ColName.INC_T2] = report_data[ColName.INC_T2].fillna('')
-    # for "Other" 2nd types, set to description instead of "Other"
-    report_data[ColName.INC_T2] = report_data.apply(
-        lambda r: (r[ColName.INC_T2_OLD] if r[ColName.INC_T2].lower() == 'other'
-                   else r[ColName.INC_T2]),
-        axis=1)
+        :param report_data:
+        :return: The updated data.
+        """
+        pd.set_option('display.max_columns', None)
+        # create new column and add to end of DataFrame
+        report_data[ColName.INC_T1] = report_data[ColName.INC_T1_OLD].fillna(
+            '') + report_data[ColName.INC_T1].fillna('')
+        # preprocess, replace nan with empty string
+        report_data[ColName.INC_T2] = report_data[ColName.INC_T2].fillna('')
+        # for "Other" 2nd types, set to description instead of "Other"
+        report_data[ColName.INC_T2] = report_data.apply(
+            lambda r: (r[ColName.INC_T2_OLD] if r[ColName.INC_T2].lower() == 'other'
+                       else r[ColName.INC_T2]),
+            axis=1)
 
-    # make blank if matching first incident type
-    report_data[ColName.INC_T2] = report_data.apply(
-        lambda r: (r[ColName.INC_T2] if r[ColName.INC_T1] != r[ColName.INC_T2] else ''),
-        axis=1)
+        # make blank if matching first incident type
+        report_data[ColName.INC_T2] = report_data.apply(
+            lambda r: (r[ColName.INC_T2] if r[ColName.INC_T1] != r[ColName.INC_T2] else ''),
+            axis=1)
 
-    # remove old columns
-    return report_data[[col for col in report_data if col not in [ColName.INC_T1_OLD, ColName.INC_T2_OLD]]]
+        # remove old columns
+        return report_data[[col for col in report_data if col not in [ColName.INC_T1_OLD, ColName.INC_T2_OLD]]]
+
+

--- a/preprocess/incident_types/mapper.py
+++ b/preprocess/incident_types/mapper.py
@@ -11,7 +11,7 @@ def normalize_inc_type(col: pd.Series) -> pd.Series:
     return col.str.strip().str.capitalize()
 
 
-class Mapper(Preprocessor):
+class IncTypeMapper(Preprocessor):
     """Maps old incident types to their current dropdown counterparts."""
     col_names: Iterable[str] = {
         ColName.INC_T1,

--- a/preprocess/incident_types/mapper.py
+++ b/preprocess/incident_types/mapper.py
@@ -1,0 +1,35 @@
+from typing import Iterable
+
+import pandas as pd
+
+from incident_types.incident_types_d import replacements
+from preprocessor import Preprocessor
+from report_data_d import ColName
+
+
+def normalize_inc_type(col: pd.Series) -> pd.Series:
+    return col.str.strip().str.capitalize()
+
+
+class Mapper(Preprocessor):
+    """Maps old incident types to their current dropdown counterparts."""
+    col_names: Iterable[str] = {
+        ColName.INC_T1,
+        ColName.INC_T1_OLD,
+        ColName.INC_T2,
+        ColName.INC_T2_OLD,
+    }
+
+    def __init__(self, col_names: Iterable[str] = None):
+        """
+        :param col_names: The names of the incident type columns to process
+        """
+        if col_names is not None:
+            self.col_names = col_names
+
+    def process(self, report_data: pd.DataFrame) -> pd.DataFrame:
+        for col_name in self.col_names:
+            report_data[col_name] = normalize_inc_type(report_data[col_name])
+            report_data[col_name].replace(replacements, inplace=True)
+
+        return report_data

--- a/preprocess/incident_types/processor.py
+++ b/preprocess/incident_types/processor.py
@@ -1,37 +1,12 @@
-from typing import Iterable
-
 import pandas as pd
 
-from incident_types.column_merge import merge_columns
-from incident_types.incident_types_d import replacements
+from incident_types.column_merge import ColumnMerger
+from incident_types.mapper import Mapper
 from preprocessor import Preprocessor
-from report_data_d import ColName
-
-
-def normalize_inc_type(col: pd.Series) -> pd.Series:
-    return col.str.strip().str.capitalize()
 
 
 class IncidentTypesProcessor(Preprocessor):
-    """Normalize and apply corrections to the incident type columns."""
-
-    col_names: Iterable[str] = {
-        ColName.INC_T1,
-        ColName.INC_T1_OLD,
-        ColName.INC_T2,
-        ColName.INC_T2_OLD,
-    }
-
-    def __init__(self, col_names: Iterable[str] = None):
-        """
-        :param col_names: The names of the incident type columns to process
-        """
-        if col_names is not None:
-            self.col_names = col_names
+    """Normalize, apply corrections to, and merge the incident type columns."""
 
     def process(self, report_data: pd.DataFrame) -> pd.DataFrame:
-        for col_name in self.col_names:
-            report_data[col_name] = normalize_inc_type(report_data[col_name])
-            report_data[col_name].replace(replacements, inplace=True)
-
-        return merge_columns(report_data)
+        return ColumnMerger().process(Mapper().process(report_data))

--- a/preprocess/incident_types/processor.py
+++ b/preprocess/incident_types/processor.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from incident_types.column_merge import ColumnMerger
-from incident_types.mapper import Mapper
+from incident_types.mapper import IncTypeMapper
 from preprocessor import Preprocessor
 
 
@@ -9,4 +9,4 @@ class IncidentTypesProcessor(Preprocessor):
     """Normalize, apply corrections to, and merge the incident type columns."""
 
     def process(self, report_data: pd.DataFrame) -> pd.DataFrame:
-        return ColumnMerger().process(Mapper().process(report_data))
+        return ColumnMerger().process(IncTypeMapper().process(report_data))

--- a/preprocess/incident_types/test_mapper.py
+++ b/preprocess/incident_types/test_mapper.py
@@ -5,12 +5,12 @@ from incident_types.incident_types_d import IncidentType, replacements
 from report_data import ReportData
 
 
-class TestProcessor(unittest.TestCase):
-    def test_process(self):
-        """Ensure replacements are made as expected"""
+class TestMapper(unittest.TestCase):
+    def test_maps(self):
+        """Ensure replacements are made as expected."""
         report_df = ReportData().get_raw_report_data()
         processor.IncidentTypesProcessor().process(report_df)
-        for col_name in processor.IncidentTypesProcessor.col_names:
+        for col_name in processor.Mapper.col_names:
             for inc_type in report_df[col_name].fillna(''):
                 self.assertNotIn(inc_type, replacements.keys())
                 self.assertIn(inc_type, [v.value for v in IncidentType.__members__.values()] + [''])

--- a/preprocess/incident_types/test_mapper.py
+++ b/preprocess/incident_types/test_mapper.py
@@ -5,12 +5,12 @@ from incident_types.incident_types_d import IncidentType, replacements
 from report_data import ReportData
 
 
-class TestMapper(unittest.TestCase):
+class TestIncTypeMapper(unittest.TestCase):
     def test_maps(self):
         """Ensure replacements are made as expected."""
         report_df = ReportData().get_raw_report_data()
         processor.IncidentTypesProcessor().process(report_df)
-        for col_name in processor.Mapper.col_names:
+        for col_name in processor.IncTypeMapper.col_names:
             for inc_type in report_df[col_name].fillna(''):
                 self.assertNotIn(inc_type, replacements.keys())
                 self.assertIn(inc_type, [v.value for v in IncidentType.__members__.values()] + [''])


### PR DESCRIPTION
Example implementation for [this](https://github.com/Code-the-Change-YYC/YW-NLP-Report-Classifier/pull/12#discussion_r429577673).

Allows us to apply the column merging and mapping steps separately if needed, but also maintains the order within the combined processor.