### PR TITLE
NLP-21 Parse incident datetimes to create new columns

### DIFF
--- a/preprocess/datetime_map/mapper.py
+++ b/preprocess/datetime_map/mapper.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+from enum import Enum
+
+import pandas as pd
+from dateutil.parser import parser
+
+from preprocessor import Preprocessor
+from report_data_d import _ColName
+
+
+class TimeOfDay(Enum):
+    MORNING = 'morning'
+    AFTERNOON = 'afternoon'
+    EVENING = 'evening'
+    NIGHT = 'night'
+
+
+class DatetimeMapper(Preprocessor):
+    additional_columns = {_ColName.HOUR_OF_DAY, _ColName.TIME_OF_DAY, _ColName.WEEKDAY}
+
+    def process(self, report_data: pd.DataFrame) -> pd.DataFrame:
+        """Fill `self.additional_columns` using the value of the incident
+        datetime column.
+
+        - The hour column is given the hour of the day specified within the incident datetime column
+        - The weekday column is given a boolean indicating whether the datetime is a weekday
+        - The time of day column is given a value from `TimeOfDay` based on the time of day in the datetime
+        """
+        incident_datetimes: pd.Series = report_data[_ColName.DT_INC]
+        for i, dt_str in enumerate(incident_datetimes):
+            dt = self._parse_datetime(dt_str)
+            report_data.at[i, _ColName.HOUR_OF_DAY] = dt.hour
+            report_data.at[i, _ColName.WEEKDAY] = 0 <= dt.weekday() <= 4
+            report_data.at[i, _ColName.TIME_OF_DAY] = self._time_of_day(dt).value
+
+        return report_data
+
+    def add_columns(self, report_data: pd.DataFrame) -> pd.DataFrame:
+        """Adds `self.additional_columns` to the dataframe."""
+        column_index: int = len(report_data.columns)
+        for col in self.additional_columns:
+            report_data.insert(column_index, col, None)
+            column_index += 1
+        return report_data
+
+    @staticmethod
+    def _parse_datetime(dt_str: str) -> datetime:
+        """
+        :param dt_str: String representing a datetime.
+        :return: Object representing the datetime contained in `dt_str`.
+        """
+        return parser().parse(dt_str)
+
+    @staticmethod
+    def _time_of_day(dt: datetime) -> TimeOfDay:
+        """
+        :param dt:
+        :return: Morning between 5am and noon, afternoon between noon and 5pm,
+        evening between 5pm and 9pm, night otherwise.
+        """
+        hour = dt.hour
+        if 5 <= hour <= 11:
+            return TimeOfDay.MORNING
+        elif 12 <= hour <= 16:
+            return TimeOfDay.AFTERNOON
+        elif 17 <= hour <= 20:
+            return TimeOfDay.EVENING
+        else:
+            return TimeOfDay.NIGHT

--- a/preprocess/datetime_map/test_mapper.py
+++ b/preprocess/datetime_map/test_mapper.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 
-from datetime_map.mapper import DatetimeMapper, TimeOfDay
+from datetime_map.mapper import DatetimeMapper
 from report_data import ReportData
 from report_data_d import _ColName
 
@@ -19,12 +19,15 @@ class TestDatetimeMapper(unittest.TestCase):
     def test_process_weekday(self):
         report_data = self.dt_mapper.process(self.report_data)
         for is_weekday in report_data[_ColName.WEEKDAY]:
-            self.assertIsInstance(is_weekday, bool)
+            self.assertIsInstance(is_weekday, int)
+            self.assertTrue(is_weekday == 0 or is_weekday == 1)
 
     def test_process_time_of_day(self):
         report_data = self.dt_mapper.process(self.report_data)
-        for time_of_day in report_data[_ColName.TIME_OF_DAY]:
-            self.assertIsInstance(TimeOfDay(time_of_day), TimeOfDay)
+        for col in _ColName.MORNING, _ColName.AFTERNOON, _ColName.EVENING, _ColName.NIGHT:
+            for cell in report_data[col]:
+                self.assertIsInstance(cell, int)
+                self.assertTrue(cell == 0 or cell == 1)
 
     def test_parse_datetime(self):
         parsed = self.dt_mapper._parse_datetime('2019-02-05 18:10:00')

--- a/preprocess/datetime_map/test_mapper.py
+++ b/preprocess/datetime_map/test_mapper.py
@@ -1,0 +1,39 @@
+import unittest
+from datetime import datetime
+
+from datetime_map.mapper import DatetimeMapper, TimeOfDay
+from report_data import ReportData
+from report_data_d import _ColName
+
+
+class TestDatetimeMapper(unittest.TestCase):
+    dt_mapper = DatetimeMapper()
+    report_data = ReportData(in_file_path='../data/data-sensitive.csv').get_raw_report_data()
+
+    def test_process_hour_of_day(self):
+        report_data = self.dt_mapper.process(self.report_data)
+        for hour in report_data[_ColName.HOUR_OF_DAY]:
+            self.assertIsInstance(hour, int)
+            self.assertIn(hour, range(0, 24))
+
+    def test_process_weekday(self):
+        report_data = self.dt_mapper.process(self.report_data)
+        for is_weekday in report_data[_ColName.WEEKDAY]:
+            self.assertIsInstance(is_weekday, bool)
+
+    def test_process_time_of_day(self):
+        report_data = self.dt_mapper.process(self.report_data)
+        for time_of_day in report_data[_ColName.TIME_OF_DAY]:
+            self.assertIsInstance(TimeOfDay(time_of_day), TimeOfDay)
+
+    def test_parse_datetime(self):
+        parsed = self.dt_mapper._parse_datetime('2019-02-05 18:10:00')
+        expected = datetime(2019, 2, 5, 18, 10, 0)
+        self.assertEqual(expected, parsed)
+        parsed = self.dt_mapper._parse_datetime('2020-05-02 09:30:00')
+        expected = datetime(2020, 5, 2, 9, 30, 0)
+        self.assertEqual(expected, parsed)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/preprocess/preprocessor.py
+++ b/preprocess/preprocessor.py
@@ -13,3 +13,13 @@ class Preprocessor(ABC):
         :return: The updated data.
         """
         ...
+
+    def add_columns(self, report_data: pd.DataFrame) -> pd.DataFrame:
+        """Override this to add any additional columns created by this
+        preprocessor step to the dataframe.
+
+        :param report_data: Data to which the columns are added. NOTE: This method can modify
+        this value.
+        :return: The updated data.
+        """
+        return report_data

--- a/preprocess/report_data.py
+++ b/preprocess/report_data.py
@@ -3,6 +3,7 @@ from typing import List, Type
 
 import pandas as pd
 
+from datetime_map.mapper import DatetimeMapper
 from incident_types.processor import IncidentTypesProcessor
 from preprocessor import Preprocessor
 from report_data_d import _ColName, ColName
@@ -12,7 +13,8 @@ from scrub.description_scrub import DescriptionScrubber
 class ReportData:
     pipeline: List[Type[Preprocessor]] = [
         DescriptionScrubber,
-        IncidentTypesProcessor
+        IncidentTypesProcessor,
+        DatetimeMapper
     ]
     in_file_path: str
     out_file_path: str
@@ -32,6 +34,9 @@ class ReportData:
         """
         # use pandas to get csv description column
         report_df = pd.read_csv(self.in_file_path)
+        # Add all additional columns not included in the original csv
+        for processor in self.pipeline:
+            report_df = processor().add_columns(report_df)
         # Use enum for column access. This works because enum's are iterable and
         # ordered.
         report_df.columns = _ColName

--- a/preprocess/report_data_d.py
+++ b/preprocess/report_data_d.py
@@ -42,10 +42,14 @@ class _ColName(Enum):
     DT_WRIT = "DATETIME_WRITTEN"
     """Contains the hour of the day during which the incident occurred."""
     HOUR_OF_DAY = "HOUR_OF_DAY"
-    """Contains a string representing the time of the day (morning, evening,
-    etc.) during which the incident occurred."""
-    TIME_OF_DAY = "TIME_OF_DAY"
-    """Contains a boolean indicating whether the incident occurred on a weekday."""
+    """1/0 representing the time of the day (morning, evening, etc.) during
+    which the incident occurred."""
+    MORNING = "MORNING"
+    AFTERNOON = "AFTERNOON"
+    EVENING = "EVENING"
+    NIGHT = "NIGHT"
+    """Contains 1/0 indicating whether the incident occurred on a
+    weekday."""
     WEEKDAY = "WEEKDAY"
 
     def __str__(self):

--- a/preprocess/report_data_d.py
+++ b/preprocess/report_data_d.py
@@ -40,6 +40,13 @@ class _ColName(Enum):
     RES_O = "RESPONSE_OTHER"
     RES_OD = "RESPONSE_OTHER_DESC"
     DT_WRIT = "DATETIME_WRITTEN"
+    """Contains the hour of the day during which the incident occurred."""
+    HOUR_OF_DAY = "HOUR_OF_DAY"
+    """Contains a string representing the time of the day (morning, evening,
+    etc.) during which the incident occurred."""
+    TIME_OF_DAY = "TIME_OF_DAY"
+    """Contains a boolean indicating whether the incident occurred on a weekday."""
+    WEEKDAY = "WEEKDAY"
 
     def __str__(self):
         """Overridden so that we can use this enum as the value of the


### PR DESCRIPTION
Adds columns containing the hour of the day, whether the incident occurred on a weekday, and the time of day (e.g. morning).

Also add support for preprocessors to add new columns to the report data by overriding `Preprocessor.add_columns` after adding (by hand) the column names to the end of the `_ColName` enum.