### PR TITLE
add nltk lemmatizer as preprocessing step

### DIFF
--- a/preprocess/lemmatize/ntlk_lemmatize.py
+++ b/preprocess/lemmatize/ntlk_lemmatize.py
@@ -1,0 +1,56 @@
+from preprocess.preprocessor import Preprocessor
+
+import pandas as pd
+from nltk.stem import WordNetLemmatizer
+from nltk import pos_tag
+from nltk.corpus import wordnet
+from report_data_d import _ColName
+
+
+class NLTKLemmatizer(Preprocessor):
+    lemmatizer = WordNetLemmatizer()
+
+    @staticmethod
+    def nltk_to_wordnet(nltk_tag):
+        """
+
+        :param nltk_tag: the nltk_tag object originating from the pos_tag() function from nltk.
+        :return: the wordnet tag object, e.g., wordnet.NOUN
+        """
+
+        if nltk_tag.startswith("J"):
+            return wordnet.ADJ
+        elif nltk_tag.startswith("V"):
+            return wordnet.VERB
+        elif nltk_tag.startswith("N"):
+            return wordnet.NOUN
+        elif nltk_tag.startswith("R"):
+            return wordnet.ADV
+        else:
+            return None
+
+    def process(self, report_data: pd.DataFrame) -> pd.DataFrame:
+        """
+
+        :param report_data: Data to be lemmatized. Ideally, this data should have punctuation removed.
+        NOTE: This method can modify this value.
+        :return: The lemmatized data.
+        """
+        descriptions = report_data[_ColName.DESC]
+        lemmatized_descriptions = []
+        # loop to lemmatize
+        for description in descriptions:
+            # tokenize to input each word into lemmatize function
+            tokens = description.split()
+            # returns tuple of (token, nltk_tag)
+            tokens_tagged = pos_tag(tokens)
+            for i in range(len(tokens)):
+                token, token_tag = tokens_tagged[i][0], self.nltk_to_wordnet(tokens_tagged[i][1])
+                if token_tag:
+                    # only lemmatize if matching POS tag is found
+                    tokens[i] = self.lemmatizer.lemmatize(token, token_tag)
+
+            lemmatized_descriptions.append(" ".join(tokens))
+
+        report_data[_ColName.DESC] = lemmatized_descriptions
+        return report_data

--- a/preprocess/report_data.py
+++ b/preprocess/report_data.py
@@ -7,6 +7,7 @@ from incident_types.processor import IncidentTypesProcessor
 from clean.word_character_filter import WordCharacterFilter
 from clean.lowercaser import Lowercaser
 from preprocessor import Preprocessor
+from lemmatize.ntlk_lemmatize import NLTKLemmatizer
 from report_data_d import _ColName, ColName
 from scrub.description_scrub import DescriptionScrubber
 
@@ -16,7 +17,8 @@ class ReportData:
         DescriptionScrubber,
         IncidentTypesProcessor,
         WordCharacterFilter,
-        Lowercaser
+        Lowercaser,
+        NLTKLemmatizer
     ]
     in_file_path: str
     out_file_path: str


### PR DESCRIPTION
Uses NLTK's POS tagging in conjuction with the NLTK wordnet lemmatizer for accurate lemmatizing. Does no stemming so far.

Requires the following script to be run in the python terminal before it works:

```
import nltk
nltk.download("wordnet")
nltk.download("averaged_perceptron_tagger")
```