### PR TITLE
Add multi-prediction support

### DIFF
--- a/models/cnb_model.py
+++ b/models/cnb_model.py
@@ -1,11 +1,12 @@
 import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.naive_bayes import ComplementNB
 from sklearn.pipeline import Pipeline
 
 from incident_types.incident_types_d import IncidentType
 from models.model import Model, ArrayLike
 from report_data import ReportData
 from report_data_d import ColName
-
 from training.description_classification.utils import load_cnb, CNBPipeline
 
 
@@ -26,10 +27,63 @@ class CNBDescriptionClf(Model[CNBPipeline]):
         return np.array([IncidentType(prediction) for prediction in predictions])
 
     def partial_fit(self, X: ArrayLike, y: ArrayLike, classes: ArrayLike = None) -> object:
-        pass
+        est: ComplementNB = self._model.steps[-1][1]
+        word_vec: TfidfVectorizer = self._model.steps[0][1]
+        vectors = word_vec.transform(X)
+        est.partial_fit(vectors, y)
+        return self
+
+    def predict_multiple(self, X: ArrayLike, num_predictions: int) -> np.ndarray:
+        """Give the top `num_predictions` predictions for each sample with their
+        confidences, ordered by confidence.
+
+        :param X: Input descriptions to predict on.
+        :param num_predictions: The number of predictions to give for each
+        sample. If this is greater than the number of possible predictions, all
+        predictions will be given.
+        :return: `(X_0, num_predictions, 2)` array `Y` of prediction sets for
+        each description, where each row of `Y` is a list of predictions ordered
+        by confidence, and each prediction is an 2 length array with the
+        `IncidentType` prediction as the first element and the confidence as the
+        second.
+        """
+        classes = self._model.classes_
+        num_classes = len(classes)
+        if num_predictions > num_classes:
+            num_predictions = num_classes
+
+        return self._predictions_with_proba(self._model.predict_proba(X), num_predictions)
+
+    def _predictions_with_proba(self, proba: ArrayLike, num_predictions: int) -> np.ndarray:
+        """Utility for joining probabilities with their incident type
+        predictions and ordering them.
+
+        :param proba: Probabilities, for example as returned by `predict_proba`.
+        :param num_predictions: The number of predictions to give for each
+        sample.
+        :return: `(proba_0, num_predictions, 2)` array `Y` of prediction sets
+        for each row of probabilities, where each row of `Y` is a list of
+        predictions ordered by confidence, and each prediction is an 2 length
+        array with the `IncidentType` prediction as the first element and the
+        confidence as the second.
+        """
+        top_indices: np.ndarray = proba.argsort()[:, -1:-(num_predictions + 1):-1]
+        top_proba: np.ndarray = np.take_along_axis(proba, top_indices, axis=1)
+        predictions: np.ndarray = self._model.classes_[top_indices]
+        incident_types = np.array([IncidentType(p) for p in predictions.flat]).reshape(predictions.shape)
+        return np.dstack((incident_types, top_proba))
 
 
 if __name__ == '__main__':
     clf = CNBDescriptionClf()
     df = ReportData().get_processed_data()
-    print(clf.predict([df[ColName.DESC][0]]))
+    X = df[ColName.DESC][:5]
+    y = df[ColName.INC_T1][:5]
+    clf.partial_fit(X, y, list(set(y)))
+    print(clf.predict(X))
+    multi_predict = clf.predict_multiple(X, 5)
+    for i, prediction_set in enumerate(multi_predict):
+        print('For description')
+        print(X[i])
+        for prediction_with_proba in prediction_set:
+            print(f'We predict {prediction_with_proba[0].value} with {prediction_with_proba[1]:.2f}% confidence')

--- a/models/model.py
+++ b/models/model.py
@@ -4,7 +4,7 @@ from typing import NewType, Union, Iterable, TypeVar, Generic
 import numpy as np
 
 """Numpy array_like type"""
-ArrayLike = NewType('ArrayLike', Union[np.ndarray, Iterable, int, float])
+ArrayLike = Union[np.ndarray, Iterable, int, float]
 
 T = TypeVar('T')
 

--- a/tests/models/test_cnb_model.py
+++ b/tests/models/test_cnb_model.py
@@ -1,0 +1,24 @@
+import unittest
+
+import numpy as np
+
+from incident_types.incident_types_d import IncidentType
+from models.cnb_model import CNBDescriptionClf
+
+
+class TestCNBDescriptionClf(unittest.TestCase):
+    def test_predictions_with_proba(self):
+        clf = CNBDescriptionClf()
+        classes = clf._model.classes_
+        num_classes = len(classes)
+        single_proba = list(range(num_classes, 0, -1))
+        proba = np.array([single_proba for _ in range(3)])
+        result = clf._predictions_with_proba(proba, 3)
+        for prediction_set in result:
+            for i, prediction_with_proba in enumerate(prediction_set):
+                self.assertEqual(prediction_with_proba[0], IncidentType(classes[i]))
+                self.assertEqual(prediction_with_proba[1], single_proba[i])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allow CNB to give the top n predictions with their confidence values. See the bottom of `cnb_model.py` for example usage.