### PR TITLE
NLP-109 Move Sanity credentials to credentials.json file

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,9 +14,6 @@ clf = CNBDescriptionClf()
 credentials = Credentials()
 interceptum = InterceptumAdapter(credentials)
 
-SANITY_READ_TOKEN = 'skagnXfvkArS8Su6sEsTxpvQWB0bNBKS8X6RUr3Y6ytzOT1wg1VH6vF75EPY7JYKjZNcfMYdrCIfTIGq5DEFVBuOS8sOVus6j3ntfvcWnZ5rzFEKfsWLkApp0CU8SMUQFq6zeWKWiTGx0H0prFkP24Cud9n25B6jP9c2q1jxMpGlaS1o9pXL'
-SANITY_GQL_ENDPOINT = 'https://olnd0a1o.api.sanity.io/v1/graphql/production/default'
-
 formQuery = """
     {
         CirForm(id: "cirForm") {
@@ -28,7 +25,7 @@ formQuery = """
 headers = {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
-    'Authorization': f'Bearer {SANITY_READ_TOKEN}',
+    'Authorization': f'Bearer {credentials.sanity_read_token}',
 }
 
 
@@ -57,7 +54,7 @@ async def predict(predict_in: PredictIn) -> PredictOut:
         PredictMultiOut: JSON containing input text and predictions with their
         probabilities.
     """
-    inc_types = run_query(SANITY_GQL_ENDPOINT, formQuery, headers)['data']['CirForm']['primaryIncTypes']
+    inc_types = run_query(credentials.sanity_gql_endpoint, formQuery, headers)['data']['CirForm']['primaryIncTypes']
     input_string = predict_in.text
     num_predictions = predict_in.num_predictions
     [predictions] = clf.predict_multiple([input_string], num_predictions)

--- a/server/credentials.py
+++ b/server/credentials.py
@@ -28,6 +28,16 @@ class Credentials:
             self._credentials = json.load(cred_file)
 
     @property
+    def sanity_gql_endpoint(self) -> str:
+        """The Sanity GraphQL endpoint."""
+        return self['sanityGqlEndpoint']
+
+    @property
+    def sanity_read_token(self) -> str:
+        """The auth token required for reading from Sanity."""
+        return self['sanityReadToken']
+
+    @property
     def account_name(self) -> str:
         """The Interceptum account name."""
         return self['accountName']


### PR DESCRIPTION
This moves the Sanity read token and endpoint in the server from variables to the credentials file. The updated `credentials.json` is in Google Drive.