### PR TITLE
global credentials object

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import requests
 
-from server.credentials import Credentials
+from server.credentials import credentials
 from server.interceptum_adapter import InterceptumAdapter
 from server.risk_scores.risk_assessment import get_risk_assessment
 from fastapi import FastAPI, HTTPException
@@ -11,7 +11,6 @@ from server.schemas.submit import Form, SubmitOut, SubmitIn
 
 app = FastAPI()
 clf = CNBDescriptionClf()
-credentials = Credentials()
 interceptum = InterceptumAdapter(credentials)
 
 formQuery = """

--- a/models/cnb_model.py
+++ b/models/cnb_model.py
@@ -1,4 +1,5 @@
-from server.credentials import Credentials
+from server import credentials
+from server.credentials import credentials
 from typing import List, Optional
 
 import numpy as np
@@ -15,7 +16,7 @@ from training.description_classification.utils import load_cnb, CNBPipeline, sav
 PROD = 'production'
 DEV = 'development'
 
-IS_DEV = Credentials().PYTHON_ENV == DEV
+IS_DEV = credentials.PYTHON_ENV == DEV
 
 class CNBDescriptionClf(Model[CNBPipeline]):
     """Complement Naive Bayes model for description classification."""

--- a/server/credentials.py
+++ b/server/credentials.py
@@ -68,3 +68,5 @@ class Credentials:
             raise CredentialsError(
                 f'Could not retrieve credential with key {cred_name}.')
         return self._credentials[cred_name]
+
+credentials = Credentials()


### PR DESCRIPTION
I thought it'd be better to just init a global `credentials = Credentials()` object rather than init a new one wherever it's used. super minor, feel free to reject if not good idea.