### PR TITLE
stop github classifying as notebook repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
this will take the `Jupyter Notebook` out of the languages from the repo page. just for the aesthetics lolol