### PR TITLE
[NLP-178] Webhook Networking

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ async def submit_form(form: SubmitIn,
                      redirect_url=redirect_url)
 
 
-@app.post('/api/interceptum-post', response_model=SubmitOut)
+@app.post('/webhook/interceptum-post', response_model=SubmitOut)
 async def interceptum_post_form(form_dict: Dict,
                                 background_tasks: BackgroundTasks) -> SubmitOut:
     """Currently unusable."""
@@ -105,7 +105,7 @@ async def interceptum_post_form(form_dict: Dict,
         background_tasks.add_task(background_processing, form_dict)
 
 
-@app.post("/api/sanity-update/")
+@app.post("/webhook/sanity-update/")
 async def sanity_update(sanity_update_in: SanityUpdate):
     """Endpoint for retraining the model when relevant changes to the form
     fields occur in Sanity.

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+from preprocess.report_data_d import _ColName
 from typing import Dict
 from preprocess.report_data import ReportData
 import requests
@@ -5,7 +6,7 @@ import pandas as pd
 
 from server.credentials import credentials
 from server.interceptum_adapter import InterceptumAdapter
-from server.risk_scores.risk_assessment import get_risk_assessment
+from server.risk_scores.risk_assessment import RiskAssessment, get_risk_assessment
 from fastapi import FastAPI, HTTPException, BackgroundTasks, UploadFile, File
 
 from models.cnb_model import CNBDescriptionClf
@@ -120,10 +121,9 @@ async def sanity_update(sanity_update_in: SanityUpdate):
 
 
 @app.post('/api/retrain')
-async def retrain_model(csv_file: UploadFile = File(..., media_type='text/csv'),
-                        descriptions_column: str = None,
-                        types_column: str = None):
-    dataframe = pd.read_csv(csv_file.file)
-    descriptions = dataframe[descriptions_column].to_numpy()
-    types = dataframe[types_column].to_numpy()
+async def retrain_model(csv_file: UploadFile = File(..., media_type='text/csv')):
+    report_data = ReportData()
+    dataframe = report_data.process_report_data(csv_file.file)
+    descriptions = dataframe[_ColName.DESC].to_numpy()
+    types = dataframe[_ColName.INC_T1].to_numpy()
     clf.retrain_model(descriptions, types)

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks
 
 from models.cnb_model import CNBDescriptionClf
 from server.schemas.predict import PredictIn, PredictOut
-from server.schemas.submit import Form, SubmitOut, SubmitIn
+from server.schemas.submit import Form, SanityUpdate, SubmitOut, SubmitIn
 from server.connection import collection
 
 app = FastAPI()
@@ -130,3 +130,9 @@ async def submit_form(form: SubmitIn,
 async def interceptum_post_form(form_dict: Dict,
                                 background_tasks: BackgroundTasks) -> SubmitOut:
     background_tasks.add_task(background_processing, form_dict)
+
+
+@app.post("/api/sanity-update/")
+async def sanity_update(sanity_update_in: SanityUpdate):
+    print(sanity_update_in)
+

--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 from typing import Dict
-
 from preprocess.report_data import ReportData
 import requests
 import pandas as pd
@@ -57,7 +56,7 @@ async def predict(predict_in: PredictIn) -> PredictOut:
     input_string = predict_in.text
     num_predictions = predict_in.num_predictions
     [predictions] = clf.predict_multiple([input_string], num_predictions)
-    predictions = [(pred[0], pred[1]) for pred in predictions]
+    predictions = [(pred[0], float(pred[1])) for pred in predictions]
     predictions = list(filter(lambda pred: pred[0] in inc_types, predictions))
     return PredictOut(input_text=input_string, predictions=predictions)
 
@@ -98,7 +97,24 @@ async def interceptum_post_form(form_dict: Dict,
 
 @app.post("/api/sanity-update/")
 async def sanity_update(sanity_update_in: SanityUpdate):
-    print(sanity_update_in)
+    """Endpoint for retraining the model when relevant changes to the form
+    fields occur in Sanity.
+    Assumes all data in the database has undergone preprocessing.
+    """
+    all_incidents_query = collection.find(projection=['description', 'incident_type_primary'])
+    all_incidents = pd.DataFrame(list(all_incidents_query))
+    # get all from database, map into DataFrame
+    # pass into training function that receives DataFrame
+    # in preprocessing step of training function, filter out training examples
+    # with obsolete incident types
+    # TODO: Check if "cirForm" is in this array, only update model if it is.
+    sanity_update_in.ids.all
+    # for incident in all_incidents:
+    #     print(incident)
+    # print(sanity_update_in)
+    # clf.retrain_model(all_incidents['description'], all_incidents['incident_type_primary'])
+
+# Need to filter out past incident types that have been deleted
 
 
 @app.post('/api/retrain')

--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ async def predict(predict_in: PredictIn) -> PredictOut:
     input_string = predict_in.text
     num_predictions = predict_in.num_predictions
     [predictions] = clf.predict_multiple([input_string], num_predictions)
-    predictions = [(pred[0].value, pred[1]) for pred in predictions]
+    predictions = [(pred[0], pred[1]) for pred in predictions]
     predictions = list(filter(lambda pred: pred[0] in inc_types, predictions))
     return PredictOut(input_text=input_string, predictions=predictions)
 

--- a/client/nginx/nginx.conf
+++ b/client/nginx/nginx.conf
@@ -5,18 +5,36 @@ upstream server {
 server {
     listen 80;
 
+    location /webhook {
+        proxy_pass http://server;
+        proxy_set_header   Host ${DOLLAR}host;
+        proxy_set_header   X-Real-IP ${DOLLAR}remote_addr;
+        proxy_set_header   X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Host ${DOLLAR}server_name;
+    }
+
     location ~ /api {
         proxy_pass http://server;
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   Host ${DOLLAR}host;
+        proxy_set_header   X-Real-IP ${DOLLAR}remote_addr;
+        proxy_set_header   X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Host ${DOLLAR}server_name;
+        # Allow only private address space as described here: https://www.arin.net/reference/research/statistics/address_filters/
+        allow 10.0.0.0-10.255.255.255;
+        allow 172.16.0.0-172.31.255.255
+        allow 192.168.0.0-192.168.255.255;
+        deny all;
     }
 
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
-        try_files $uri $uri/ /index.html;
+        try_files ${DOLLAR}uri ${DOLLAR}uri/ /index.html;
+        # Allow only private address space as described here: https://www.arin.net/reference/research/statistics/address_filters/
+        allow 10.0.0.0-10.255.255.255;
+        allow 172.16.0.0-172.31.255.255
+        allow 192.168.0.0-192.168.255.255;
+        deny all;
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/models/cnb_model.py
+++ b/models/cnb_model.py
@@ -8,7 +8,6 @@ from sklearn.naive_bayes import ComplementNB
 from sklearn.pipeline import Pipeline, make_pipeline
 
 from training.description_classification import model_paths
-from preprocess.incident_types.incident_types_d import IncidentType
 from models.model import Model, ArrayLike
 from preprocess.report_data import ReportData
 from preprocess.report_data_d import ColName
@@ -47,7 +46,7 @@ class CNBDescriptionClf(Model[CNBPipeline]):
         """
         predictions = self._model.predict(X)
         return np.array(
-            [IncidentType(prediction) for prediction in predictions])
+            [prediction for prediction in predictions])
 
     def partial_fit(self, X: ArrayLike, y: List[str]):
         """Update the model and save the updates.
@@ -128,7 +127,7 @@ class CNBDescriptionClf(Model[CNBPipeline]):
                                                   -1:-(num_predictions + 1):-1]
         top_proba: np.ndarray = np.take_along_axis(proba, top_indices, axis=1)
         predictions: np.ndarray = self._model.classes_[top_indices]
-        incident_types = np.array([IncidentType(p) for p in predictions.flat
+        incident_types = np.array([p for p in predictions.flat
                                   ]).reshape(predictions.shape)
         return np.dstack((incident_types, top_proba))
 
@@ -175,5 +174,5 @@ if __name__ == "__main__":
         print(X[i])
         for prediction_with_proba in prediction_set:
             print(
-                f"We predict {prediction_with_proba[0].value} with {prediction_with_proba[1]:.2f}% confidence"
+                f"We predict {prediction_with_proba[0]} with {prediction_with_proba[1]:.2f}% confidence"
             )

--- a/models/cnb_model.py
+++ b/models/cnb_model.py
@@ -81,7 +81,7 @@ class CNBDescriptionClf(Model[CNBPipeline]):
         each description, where each row of `Y` is a list of predictions ordered
         by confidence, and each prediction is an 2 length array with the
         `IncidentType` prediction as the first element and the confidence as the
-        second.
+        second. The confidence values are represented as strings.
         """
         num_classes = len(self._model.classes_)
         if not num_predictions or num_predictions > num_classes:
@@ -132,7 +132,7 @@ class CNBDescriptionClf(Model[CNBPipeline]):
         for each row of probabilities, where each row of `Y` is a list of
         predictions ordered by confidence, and each prediction is an 2 length
         array with the `IncidentType` prediction as the first element and the
-        confidence as the second.
+        confidence as the second. The confidence values are represented as strings.
         """
         top_indices: np.ndarray = proba.argsort()[:,
                                                   -1:-(num_predictions + 1):-1]

--- a/models/cnb_model.py
+++ b/models/cnb_model.py
@@ -96,9 +96,9 @@ class CNBDescriptionClf(Model[CNBPipeline]):
         given data.
 
         Params:
-            descriptions: Descriptions to train on.
+            descriptions: Descriptions to train on. Must not contains missing values.
 
-            incident_types: The incident types corresponding to the descriptions.
+            incident_types: The incident types corresponding to the descriptions. Must not contains missing values.
 
             all_incident_types: All possible incident types which the model
             might receive. If this is not given, the unique values from
@@ -134,6 +134,7 @@ class CNBDescriptionClf(Model[CNBPipeline]):
         """
         save_cnb(self._model, model_path=model_paths.cnb_backup_file_name)
         self._model = self.create_model(descriptions, incident_types, all_incident_types=all_incident_types)
+        save_cnb(self._model, model_path=self._model_path)
 
     def _predictions_with_proba(self, proba: ArrayLike,
                                 num_predictions: int) -> np.ndarray:

--- a/models/svm_model.py
+++ b/models/svm_model.py
@@ -1,7 +1,6 @@
 import numpy as np
 from sklearn.pipeline import Pipeline
 
-from preprocess.incident_types.incident_types_d import IncidentType
 from models.model import Model, ArrayLike
 from preprocess.report_data import ReportData
 from preprocess.report_data_d import ColName
@@ -26,7 +25,7 @@ class SVMDescriptionClf(Model[SVMPipeline]):
             1D array of `IncidentType` predictions for the given descriptions.
         """
         predictions = self._model.predict(X)
-        return np.array([IncidentType(prediction) for prediction in predictions])
+        return np.array([prediction for prediction in predictions])
 
     def partial_fit(self, X: ArrayLike, y: ArrayLike, classes: ArrayLike = None) -> object:
         pass

--- a/server/schemas/submit.py
+++ b/server/schemas/submit.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, TypedDict
 
 from pydantic import BaseModel
 
@@ -61,3 +61,17 @@ class SubmitOut(BaseModel):
     form_fields: Form
     risk_assessment: str
     redirect_url: str
+
+
+class SanityUpdateIds(BaseModel):
+    created: List[str]
+    deleted: List[str]
+    updated: List[str]
+    all: List[str]
+
+
+class SanityUpdate(BaseModel):
+  transactionId: str
+  projectId: str
+  dataset: str
+  ids: SanityUpdateIds

--- a/tests/models/test_cnb_model.py
+++ b/tests/models/test_cnb_model.py
@@ -47,8 +47,8 @@ class TestCNBDescriptionClf(unittest.TestCase):
         result = clf._predictions_with_proba(proba, 3)
         for prediction_set in result:
             for i, prediction_with_proba in enumerate(prediction_set):
-                self.assertEqual(prediction_with_proba[0], IncidentType(classes[i]))
-                self.assertEqual(prediction_with_proba[1], single_proba[i])
+                self.assertEqual(prediction_with_proba[0], classes[i])
+                self.assertEqual(float(prediction_with_proba[1]), single_proba[i])
 
     def test_partial_fit_handles_new_classes(self):
         # Create a copy of the model to use for testing

--- a/tests/models/test_cnb_model.py
+++ b/tests/models/test_cnb_model.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 from training.description_classification.utils import save_cnb
 import unittest
@@ -17,8 +18,51 @@ test_inc_types = [
     IncidentType.ABU_CLI.value
 ]
 
+@contextlib.contextmanager
+def test_model_context():
+    # Create a copy of the model to use for testing
+    test_model_path = 'cnb_desc_clf.test.pickle'
+    with open(model_paths.cnb, 'rb') as prod_model, open(test_model_path, 'wb') as model:
+        model.write(prod_model.read())
+
+    try:
+        clf = CNBDescriptionClf(model_path=test_model_path)
+        yield clf, test_model_path
+    finally:
+        os.remove(test_model_path)
 
 class TestCNBDescriptionClf(unittest.TestCase):
+
+    def test_retrain_model_fewer_incident_types(self):
+        """Asserts that retraining the model with a list of all incident types
+        that does not include some incident types in the training examples does
+        not break things. For example, if an incident type is removed in Sanity,
+        but we still have descriptions with those as incident types in the
+        dataset, the model should handle that."""
+        with test_model_context() as (clf, test_model_path):
+            test_inc_types_fewer = test_inc_types[1:]
+            clf.retrain_model(test_descriptions, test_inc_types, all_incident_types=test_inc_types_fewer)
+            self.assertSetEqual(set(test_inc_types_fewer), set(clf._model.classes_))
+            clf.predict(['a description'])
+            test_descriptions_fewer = test_descriptions[1:]
+            clf.partial_fit(test_descriptions_fewer, test_inc_types_fewer)
+            clf.predict(['a description'])
+
+    def test_retrain_model_extra_incident_types(self):
+        """Asserts that retraining the model with a list of all incident types
+        that includes some incident types that are not in the training examples does
+        not break things. For example, if an incident type is added in Sanity,
+        but we don't have any training examples for that type, the model should
+        handle that."""
+        with test_model_context() as (clf, test_model_path):
+            new_inc_type = "a new incident type"
+            test_inc_types_extra = test_inc_types + [new_inc_type]
+            clf.retrain_model(test_descriptions, test_inc_types, all_incident_types=test_inc_types_extra)
+            self.assertSetEqual(set(test_inc_types_extra), set(clf._model.classes_))
+            clf.predict(['a description'])
+            test_descriptions_extra = test_descriptions + ['a new description']
+            clf.partial_fit(test_descriptions_extra, test_inc_types_extra)
+            clf.predict(['a description'])
 
     def test_create_model_integration(self):
         """Asserts that the created model doesn't break when used in the rest of
@@ -51,13 +95,7 @@ class TestCNBDescriptionClf(unittest.TestCase):
                 self.assertEqual(float(prediction_with_proba[1]), single_proba[i])
 
     def test_partial_fit_handles_new_classes(self):
-        # Create a copy of the model to use for testing
-        test_model_path = 'cnb_desc_clf.test.pickle'
-        with open(model_paths.cnb, 'rb') as prod_model, open(test_model_path, 'wb') as model:
-            model.write(prod_model.read())
-
-        try:
-            clf = CNBDescriptionClf(model_path=test_model_path)
+        with test_model_context() as (clf, test_model_path):
             previous_classes = list(clf._get_estimator().classes_)
             y = ['a wild incident type appears']
             clf.partial_fit(['a new incident occured'], y)
@@ -67,8 +105,6 @@ class TestCNBDescriptionClf(unittest.TestCase):
             
             for cls in previous_classes:
                 self.assertIn(cls, new_classes)
-        finally:
-            os.remove(test_model_path)
 
     def test_get_classes_handles_unknown(self):
         clf = CNBDescriptionClf()


### PR DESCRIPTION
Assumes Nginx server port will be publicly accessible (instead of just on the YW network), and restricts api and website endpoints to just the [local IPv4 address space](https://www.arin.net/reference/research/statistics/address_filters/), and only the webhook endpoint is publicly accessible. Webhooks should go under /webhook now instead of /api.

This branch **has not been tested**.

This branch is based off [this branch](https://github.com/Code-the-Change-YYC/YW-NLP-Report-Classifier/tree/rynoV/NLP-157/sanity-webhook) (in order to show how the webhook endpoint should be updated).