### PR TITLE
[NLP-178] Initial attempt at securing server and only exposing webhooks

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ async def submit_form(form: SubmitIn,
                      redirect_url=redirect_url)
 
 
-@app.post('/api/interceptum-post', response_model=SubmitOut)
+@app.post('/webhook/interceptum-post', response_model=SubmitOut)
 async def interceptum_post_form(form_dict: Dict,
                                 background_tasks: BackgroundTasks) -> SubmitOut:
     """Currently unusable."""
@@ -105,7 +105,7 @@ async def interceptum_post_form(form_dict: Dict,
         background_tasks.add_task(background_processing, form_dict)
 
 
-@app.post("/api/sanity-update/")
+@app.post("/webhook/sanity-update/")
 async def sanity_update(sanity_update_in: SanityUpdate):
     """Endpoint for retraining the model when relevant changes to the form
     fields occur in Sanity.

--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ async def submit_form(form: SubmitIn,
                      redirect_url=redirect_url)
 
 
-@app.post('/webhook/interceptum-post', response_model=SubmitOut)
+@app.post('/webhook/interceptum-post/', response_model=SubmitOut)
 async def interceptum_post_form(form_dict: Dict,
                                 background_tasks: BackgroundTasks) -> SubmitOut:
     """Currently unusable."""

--- a/client/nginx/nginx.conf
+++ b/client/nginx/nginx.conf
@@ -5,7 +5,7 @@ upstream server {
 server {
     listen ${NGINX_PORT};
 
-    location ~ /api {
+    location /webhook {
         proxy_pass http://server;
         proxy_set_header   Host ${DOLLAR}host;
         proxy_set_header   X-Real-IP ${DOLLAR}remote_addr;
@@ -13,10 +13,28 @@ server {
         proxy_set_header   X-Forwarded-Host ${DOLLAR}server_name;
     }
 
+    location ~ /api {
+        proxy_pass http://server;
+        proxy_set_header   Host ${DOLLAR}host;
+        proxy_set_header   X-Real-IP ${DOLLAR}remote_addr;
+        proxy_set_header   X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Host ${DOLLAR}server_name;
+        # Allow only private address space as described here: https://www.arin.net/reference/research/statistics/address_filters/
+        allow 10.0.0.0-10.255.255.255;
+        allow 172.16.0.0-172.31.255.255;
+        allow 192.168.0.0-192.168.255.255;
+        deny all;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files ${DOLLAR}uri ${DOLLAR}uri/ /index.html;
+        # Allow only private address space as described here: https://www.arin.net/reference/research/statistics/address_filters/
+        allow 10.0.0.0-10.255.255.255;
+        allow 172.16.0.0-172.31.255.255;
+        allow 192.168.0.0-192.168.255.255;
+        deny all;
     }
 
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
Assumes Nginx server port will be publicly accessible (instead of just on the YW network), and restricts api and website endpoints to just the local IPv4 address space, and only the webhook endpoint is publicly accessible. Webhooks should go under /webhook now instead of /api.