### PR TITLE
Use development sanity dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/
@@ -154,7 +154,7 @@ node_modules
 
 .devcontainer/
 
-**/credentials.json
+**/credentials.*json
 
 SANITY_TOKEN
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -9,6 +9,14 @@ Assuming the Sanity project is already set up:
 
 Most errors with the Sanity CLI can be fixed by logging out and logging back in.
 
+After making any changes to the schema, run `npm run deploy-dev-gql` so that the
+GraphQL API gets updated with the latest changes.
+
+## Deployment
+
+After making any changes to the schema which you want to deploy, run `npm run
+deploy-prod-gql` to deploy a new GraphQL API with the changes.
+
 ## Sanity Project Setup
 
 1. `npm install -D @sanity/cli`

--- a/cms/package.json
+++ b/cms/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "sanity start",
     "deploy": "sanity deploy",
-    "deploy-gql": "sanity graphql deploy --force --playground",
+    "deploy-prod-gql": "sanity graphql deploy --no-playground --dataset production",
+    "deploy-dev-gql": "sanity graphql deploy --force --playground",
     "test": "sanity check"
   },
   "keywords": [

--- a/cms/sanity.json
+++ b/cms/sanity.json
@@ -5,7 +5,7 @@
   },
   "api": {
     "projectId": "olnd0a1o",
-    "dataset": "production"
+    "dataset": "development"
   },
   "plugins": [
     "@sanity/base",


### PR DESCRIPTION
This makes changes to use a separate development Sanity dataset during development.

Changes outside of git:
- Added the `development` dataset to our Sanity project and copied the `production` data over to it
- Added the `credentials.dev.json` and `.env.dev` files to the google drive folder. These files should be used instead of their counterparts during development, as they point to the new Sanity development dataset

Still todo:
- This PR makes it so that the sanity studio shows the development dataset when run locally. If our plan was to have the YW run the studio locally, we will have to swap out `cms/sanity.json` in deployment.
- We will also need to swap out `credentials.dev.json` and `.env.dev` in deployment. Either that or we need some way to swap them dynamically based on an environment variable.
- Make new read token for development dataset